### PR TITLE
Fix version conflicts caused by PR#120

### DIFF
--- a/src/Maikebing.HealthChecks.Taos/Maikebing.HealthChecks.Taos.csproj
+++ b/src/Maikebing.HealthChecks.Taos/Maikebing.HealthChecks.Taos.csproj
@@ -17,8 +17,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="5.0.7" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="5.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="5.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="5.0.8" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump Microsoft.Extensions.Diagnostics.HealthChecks from 5.0.7 to 5.0.8. [(PR#120)](https://github.com/maikebing/Maikebing.EntityFrameworkCore.Taos/pull/120).
Hope this fix can help you.

Best regards,
sucrose